### PR TITLE
move jupyter installation to docker-edenbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,22 +9,8 @@ MAINTAINER Daniel Maticzka (maticzkd@informatik.uni-freiburg.de), Björn A. Grü
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-RUN pip install jupyter
-
 RUN mkdir /opt/EDeN
 ADD . /opt/EDeN/
 ENV PYTHONPATH $PYTHONPATH:/opt/EDeN/
 ENV PATH $PATH:/opt/EDeN/bin/
 WORKDIR /opt/EDeN
-
-## from jupyter documentation
-# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
-# kernel crashes.
-ENV TINI_VERSION v0.6.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN chmod +x /usr/bin/tini
-ENTRYPOINT ["/usr/bin/tini", "--"]
-
-RUN mkdir /export
-EXPOSE 8888
-CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--notebook-dir=/export/"]


### PR DESCRIPTION
* if the tests run this should be merged ASAP because the docker-edenbase is already update and will probably lead to conflicts if jupyter is enabled twice